### PR TITLE
Polar lab

### DIFF
--- a/.github/workflows/commit-stage.yaml
+++ b/.github/workflows/commit-stage.yaml
@@ -1,0 +1,85 @@
+name: "Commit Stage"
+on: "push"
+env:
+  REGISTRY: "ghcr.io"
+  IMAGE_NAME: "shayfoo/order-service"
+  VERSION: "latest"
+jobs:
+  build:
+    name: "Build and Test"
+    runs-on: "ubuntu-24.04"
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: "Checkout source code"
+        uses: actions/checkout@v5
+      - name: "Set up JDK 25"
+        uses: actions/setup-java@v5
+        with:
+          java-version: "25"
+          distribution: "corretto"
+          cache: "gradle"
+      - name: "Code vulnerability scanning"
+        uses: "anchore/scan-action@v6"
+        id: scan
+        with:
+          path: "${{ github.workspace }}"
+          fail-build: "false"
+          severity-cutoff: high
+      - name: "Upload vulnerability report"
+        uses: "github/codeql-action/upload-sarif@v3"
+        with:
+          sarif_file: "${{ steps.scan.outputs.sarif}}"
+      - name: "Build, unit tests and integration tests"
+        run: |
+          chmod +x gradlew
+          ./gradlew build
+      - name: Validate Kubernetes manifest
+        uses: "stackrox/kube-linter-action@v1.0.7"
+        with:
+          directory: k8s
+          fail-on-invalid-resource: true
+  package:
+    name: "Package and Publish"
+    if: "${{ github.ref == 'refs/heads/main'}}"
+    needs: [ "build" ]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+    steps:
+      - name: "Checkout source code"
+        uses: /actions/checkout@v5
+      - name: "Set up JDK 25"
+        uses: actions/setup-java@v5
+        with:
+          java-version: "25"
+          distribution: "corretto"
+          cache: "gradle"
+      - name: "Build container image"
+        run: |
+          chmod +x gradlew
+          ./gradlew  bootBuildImage\
+            --imageName ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+      - name: "Image vulnerability scanning"
+        uses: "anchore/scan-action@v6"
+        id: scan
+        with:
+          image: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}"
+          fail-build: "true"
+          severity-cutoff: high
+      - name: "Upload vulnerability report"
+        uses: "github/codeql-action/upload-sarif@v3"
+        with:
+          sarif_file: "${{ steps.scan.outputs.sarif }}"
+      - name: "Log into container registry"
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Publish container image"
+        run: |
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,18 @@
+# Build
+custom_build(
+    # Name of the container image
+    ref = 'order-service',
+    # Command to build the image - using env parameter for cross-platform compatibility
+    command='gradlew bootBuildImage --imageName %EXPECTED_REF%',
+    # files to watch for changes
+    deps=['build.gradle.kts', 'src']
+)
+
+# Deploy
+k8s_yaml(['k8s/deployment.yaml', 'k8s/service.yaml'])
+
+# Manage
+k8s_resource(
+    'order-service',
+    port_forwards=['9002']
+)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
+    implementation("org.springframework.cloud:spring-cloud-starter-config")
     runtimeOnly("org.postgresql:postgresql")
     runtimeOnly("org.postgresql:r2dbc-postgresql")
     runtimeOnly("org.flywaydb:flyway-core")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:postgresql")
     testImplementation("org.testcontainers:r2dbc")
-    testImplementation("com.squareup.okhttp3:mockwebserver:5.1.0")
+    testImplementation("org.wiremock.integrations:wiremock-spring-boot:3.10.6")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.springframework.boot.gradle.tasks.bundling.BootBuildImage
+
 plugins {
     java
     id("org.springframework.boot") version "3.5.6"
@@ -17,6 +19,8 @@ java {
 repositories {
     mavenCentral()
 }
+
+extra["springCloudVersion"] = "2025.0.0"
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
@@ -45,4 +49,29 @@ tasks.withType<Test> {
 
 tasks.withType<JavaCompile> {
     inputs.files(tasks.named("processResources"))
+}
+
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:${property("springCloudVersion")}")
+    }
+}
+
+// cloud native buildpack settings
+tasks.named<BootBuildImage>("bootBuildImage") {
+    environment = mapOf(
+        "BP_JVM_VERSION" to "25",
+        "BP_JVM_TIMEZONE" to "Asia/Tokyo",
+        "LANG" to "ja_JP.UTF-8",
+        "LANGUAGE" to "ja_JP:ja",
+        "LC_ALL" to "ja_JP.UTF-8",
+    )
+    imageName = project.name + ":" + project.version
+    docker {
+        publishRegistry {
+            username = project.findProperty("registryUsername")?.toString()
+            password = project.findProperty("registryToken")?.toString()
+            url = project.findProject("registryUrl")?.toString()
+        }
+    }
 }

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: order-service
-          image: order-service
+          image: order-service:0.0.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: order-service
+  labels:
+    app: order-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: order-service
+  template:
+    metadata:
+      labels:
+        app: order-service
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: order-service
+          image: order-service
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command: [ "sh", "-c", "sleep 5" ]
+          ports:
+            - containerPort: 9002
+          env:
+            - name: BPL_JVM_THREAD_COUNT
+              value: "50"
+            - name: SPRING_R2DBC_URL
+              value: r2dbc:postgresql://polar-postgres/polardb_order
+            - name: SPRING_FLYWAY_URL
+              value: jdbc:postgresql://polar-postgres/polardb_order
+            - name: SPRING_CLOUD_CONFIG_FAIL-FAST
+              value: "true"
+            - name: SPRING_CLOUD_CONFIG_RETRY_MAX-ATTEMPTS
+              value: "10"
+            - name: SPRING_CLOUD_CONFIG_URI
+              value: http://config-service
+            - name: POLAR_CATALOG-SERVICE-URI
+              value: http://catalog-service
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "200m"
+            limits:
+              memory: "1024Mi"
+              cpu: "400m"
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+      volumes:
+        - name: tmp
+          emptyDir: { }

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: order-service
+  labels:
+    app: order-service
+spec:
+  type: ClusterIP
+  selector:
+    app: order-service
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 9002

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,8 @@
 spring:
   application:
     name:order-service
+  config:
+    import: "optional:configserver:"
   lifecycle:
     timeout-per-shutdown-phase: 15s
   threads:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,6 +18,17 @@ spring:
     user: user
     password: password
     url: jdbc:postgresql://localhost:5432/polardb_order
+  cloud:
+    config:
+      uri: http://localhost:8888
+      request-connect-timeout: 5000
+      request-read-timeout: 5000
+      fail-fast: false
+      retry:
+        max-attempts: 6
+        initial-interval: 1000
+        max-interval: 2000
+        multiplier: 1.1
 server:
   port: 9002
   shutdown: graceful

--- a/src/test/java/com/polarbookshop/order_service/api/book/BookClientTests.java
+++ b/src/test/java/com/polarbookshop/order_service/api/book/BookClientTests.java
@@ -1,54 +1,43 @@
 package com.polarbookshop.order_service.api.book;
 
-import mockwebserver3.MockResponse;
-import mockwebserver3.MockWebServer;
-import org.junit.jupiter.api.AfterEach;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-import java.io.IOException;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
+@WireMockTest
 public class BookClientTests {
-    private MockWebServer mockWebServer;
     private BookClient bookClient;
 
     @BeforeEach
-    void setup() throws IOException {
-        this.mockWebServer = new MockWebServer();
-        this.mockWebServer.start();
+    void setup(WireMockRuntimeInfo runtimeInfo) {
         WebClient webClient = WebClient.builder()
-                .baseUrl(mockWebServer.url("/").toString())
+                .baseUrl(runtimeInfo.getHttpBaseUrl())
                 .build();
         this.bookClient = new BookClient(webClient);
-    }
-
-    @AfterEach
-    void clean() {
-        this.mockWebServer.close();
     }
 
     @Test
     void whenBookExistsThenReturnBook() {
         String bookIsbn = "1234567890";
-        MockResponse response = new MockResponse.Builder()
-                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
-                .body("""
-                        {
-                            "isbn": "%s",
-                            "title": "Title",
-                            "author": "Author",
-                            "price": 9.90,
-                            "publisher": "Polarsophia"
-                        }
-                        """.formatted(bookIsbn))
-                .build();
-        mockWebServer.enqueue(response);
-
+        stubFor(get("/books/" + bookIsbn)
+                .willReturn(
+                        okJson("""
+                                {
+                                    "isbn": "%s",
+                                    "title": "Title",
+                                    "author": "Author",
+                                    "price": 9.90,
+                                    "publisher": "Polarsophia"
+                                }
+                                """.formatted(bookIsbn))
+                ));
+        
         Mono<Book> book = bookClient.getBookByIsbn(bookIsbn);
 
         StepVerifier.create(book)


### PR DESCRIPTION
This pull request introduces Kubernetes deployment support and CI/CD automation for the `order-service`, along with configuration updates for cloud config integration. The main changes are the addition of deployment manifests, service definitions, a Tiltfile for local development, and a GitHub Actions workflow for building, testing, scanning, and publishing the container image. Configuration files have also been updated to support connecting to a Spring Cloud Config server.

**Kubernetes Deployment & Service**
* Added `k8s/deployment.yaml` to define the deployment for `order-service`, including container settings, environment variables, resource limits, and security contexts.
* Added `k8s/service.yaml` to expose the `order-service` pod within the cluster using a ClusterIP service on port 80.

**Development & CI/CD Automation**
* Added a `Tiltfile` to enable local development workflows, including custom container builds, Kubernetes resource management, and port forwarding.
* Added `.github/workflows/commit-stage.yaml` to automate building, testing, vulnerability scanning, and publishing of the container image to GitHub Container Registry, including SARIF report uploads and Kubernetes manifest validation.

**Configuration Updates**
* Updated `src/main/resources/application.yaml` to import configuration from a Spring Cloud Config server and added related connection, retry, and timeout settings. [[1]](diffhunk://#diff-b4c0421bcb3280a8e738550c830dba197057c515bcdd9579a52cbfe9adca2061R4-R5) [[2]](diffhunk://#diff-b4c0421bcb3280a8e738550c830dba197057c515bcdd9579a52cbfe9adca2061R23-R33)